### PR TITLE
Extract config using @wrhs/extract-config

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -108,10 +108,6 @@ Factory.prototype.init = function init(next) {
   const base = this.base;
   const factory = this;
 
-  //
-  // Read the package.json AND the wrhs.toml
-  //
-  debug(`Read package.json: ${ pkg } and wrhs.toml: ${ wrhs }`);
   extract(base)
     .then(({ pkg, wrhs }) => {
       debug(`Read configuration: ${ wrhs }`);

--- a/factory.js
+++ b/factory.js
@@ -107,19 +107,20 @@ Factory.prototype.init = function init(next) {
   const entry = this.data.entry;
   const base = this.base;
   const factory = this;
-  const pkg = path.join(base, 'package.json');
-  const wrhs = path.join(base, 'wrhs.toml');
 
   //
   // Read the package.json AND the wrhs.toml
   //
   debug(`Read package.json: ${ pkg } and wrhs.toml: ${ wrhs }`);
-  extract(base, (err, config) => {
-    if (err) return void next(err);
-
-    debug(`Parsed configuration`, config);
-    return void next();
-  });
+  extract(base)
+    .then({ pkg, wrhs } => {
+      debug(`Read configuration: ${ wrhs }`);
+      factory.pkg = pkg;
+      factory.entry = path.join(base, entry || pkg.main);
+      factory.config = wrhs;
+    })
+    .then(() => next())
+    .catch(err => next(err));
 };
 
 /**

--- a/factory.js
+++ b/factory.js
@@ -6,6 +6,7 @@ const cleancss = require('./minifiers/cleancss');
 const minimize = require('./minifiers/minimize');
 const uglifyjs = require('./minifiers/uglifyjs');
 const fingerprinter = require('fingerprinting');
+const extract = require('@wrhs/extract-config');
 const rmrf = require('./rmrf');
 const mkdirp = require('mkdirp');
 const gunzip = require('gunzip-maybe');
@@ -113,41 +114,10 @@ Factory.prototype.init = function init(next) {
   // Read the package.json AND the wrhs.toml
   //
   debug(`Read package.json: ${ pkg } and wrhs.toml: ${ wrhs }`);
-  async.parallel([
-    function packJson(fn) {
-      fs.readFile(pkg, 'utf-8', function read(error, content) {
-        if (error) return void fn(error);
-
-        try {
-          factory.pkg = JSON.parse(content);
-          factory.entry = path.join(base, entry || factory.pkg.main);
-        } catch (err) {
-          return fn(err);
-        }
-
-        debug(`Set entry of factory to ${ factory.entry }`);
-        debug(`Parsed package.json content`, factory.pkg);
-        return fn();
-      });
-    },
-    function whrsCfg(fn) {
-      fs.readFile(wrhs, 'utf-8', function readme(error, content) {
-        if (error && error.code === 'ENOENT') return void fn();
-        if (error) return fn(error);
-
-        try {
-          factory.config = toml.parse(content);
-        } catch (err) {
-          return fn(err);
-        }
-
-        debug(`Parsed wrhs.toml content`, factory.config);
-        return fn();
-      });
-    }
-  ], function (err) {
+  extract(base, (err, config) => {
     if (err) return void next(err);
 
+    debug(`Parsed configuration`, config);
     return void next();
   });
 };

--- a/factory.js
+++ b/factory.js
@@ -15,7 +15,6 @@ const tar = require('tar-fs');
 const errs = require('errs');
 const zlib = require('zlib');
 const path = require('path');
-const toml = require('toml');
 const util = require('util');
 const fs = require('fs');
 const os = require('os');
@@ -64,7 +63,7 @@ function Factory(data, run) {
   //
   // Default the config to empty
   //
-  this.config = { files: {}};
+  this.config = { files: {} };
   this.output = {};
   this.data = data;
   this.run = run;
@@ -356,7 +355,7 @@ Factory.prototype.line = function line(stack, done) {
  * @returns {void}
  * @api private
  */
-Factory.prototype.files = function files(fn) {
+Factory.prototype.files = function (fn) {
   var factory = this;
 
   mkdirp(this.dest, (err) => {

--- a/factory.js
+++ b/factory.js
@@ -113,7 +113,7 @@ Factory.prototype.init = function init(next) {
   //
   debug(`Read package.json: ${ pkg } and wrhs.toml: ${ wrhs }`);
   extract(base)
-    .then({ pkg, wrhs } => {
+    .then(({ pkg, wrhs }) => {
       debug(`Read configuration: ${ wrhs }`);
       factory.pkg = pkg;
       factory.entry = path.join(base, entry || pkg.main);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,23 +5,23 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.51"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
-      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+      "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51",
+        "@babel/types": "^7.3.4",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       },
@@ -35,43 +35,43 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
-      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
-      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
-      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.51"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -109,6 +109,12 @@
           "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -121,54 +127,52 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
-      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+      "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/helper-function-name": "7.0.0-beta.51",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "debug": "^3.1.0",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.3.4",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.3.4",
+        "@babel/types": "^7.3.4",
+        "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "globals": {
-          "version": "11.10.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-          "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
           "dev": true
         },
         "ms": {
@@ -180,13 +184,13 @@
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
-      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+      "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.5",
+        "lodash": "^4.17.11",
         "to-fast-properties": "^2.0.0"
       },
       "dependencies": {
@@ -195,6 +199,21 @@
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
           "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "dev": true
+        }
+      }
+    },
+    "@wrhs/extract-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@wrhs/extract-config/-/extract-config-1.0.0.tgz",
+      "integrity": "sha512-IJh4tTHkc+iSn+5wTdep0NNvmmc43m4lqVTN9PtmZeZyTbQF9hT1nTWikNZAEDDjtl5BSw+2kcoUzLNlPFhdfA==",
+      "requires": {
+        "toml": "^3.0.0"
+      },
+      "dependencies": {
+        "toml": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+          "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
         }
       }
     },
@@ -208,9 +227,9 @@
       }
     },
     "acorn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.5.tgz",
-      "integrity": "sha512-i33Zgp3XWtmZBMNvCr4azvOFeWVw1Rk6p3hfi3LUDvIFraOMywb1kAtrbi+med14m4Xfpqm3zRZMT+c0FNE7kg=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+      "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw=="
     },
     "acorn-dynamic-import": {
       "version": "4.0.0",
@@ -251,9 +270,9 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
     },
     "ajv": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.7.0.tgz",
-      "integrity": "sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
+      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -262,9 +281,9 @@
       }
     },
     "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
+      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw=="
     },
     "amdefine": {
       "version": "1.0.1",
@@ -272,9 +291,9 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -294,6 +313,16 @@
       "requires": {
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
       }
     },
     "aproba": {
@@ -1098,9 +1127,9 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "binary-extensions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
+      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
     },
     "bl": {
       "version": "1.2.2",
@@ -1441,23 +1470,22 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-      "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
+      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
       "requires": {
         "anymatch": "^2.0.0",
-        "async-each": "^1.0.0",
-        "braces": "^2.3.0",
-        "fsevents": "^1.2.2",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
-        "inherits": "^2.0.1",
+        "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
         "is-glob": "^4.0.0",
-        "lodash.debounce": "^4.0.8",
-        "normalize-path": "^2.1.1",
+        "normalize-path": "^3.0.0",
         "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0",
-        "upath": "^1.0.5"
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.0"
       }
     },
     "chownr": {
@@ -1725,9 +1753,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.3.tgz",
-      "integrity": "sha512-l00tmFFZOBHtYhN4Cz7k32VM7vTn3rE2ANjQDxdEN6zmXZ/xq1jQuutnmHvMG1ZJ7xd72+TA5YpUK8wz3rWsfQ=="
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1809,6 +1837,11 @@
       "requires": {
         "es5-ext": "~0.10.2"
       }
+    },
+    "dash-ast": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+      "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA=="
     },
     "date-now": {
       "version": "0.1.4",
@@ -1974,19 +2007,12 @@
       }
     },
     "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        }
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
       }
     },
     "domain-browser": {
@@ -2025,9 +2051,9 @@
       }
     },
     "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2134,9 +2160,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.47",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-      "integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
+      "version": "0.10.48",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
+      "integrity": "sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -2346,9 +2372,9 @@
           "dev": true
         },
         "globals": {
-          "version": "11.10.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-          "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
           "dev": true
         },
         "json-schema-traverse": {
@@ -2402,9 +2428,9 @@
       }
     },
     "eslint-plugin-json": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.3.2.tgz",
-      "integrity": "sha512-WPdA8ph8ptdlPPta7se9zhhVKd3qGmeiNJkCi6hQi5xPXPEXkXkoNGAUjVD6EXN2Df3ded1ww4jXSn6+JA65fQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.4.0.tgz",
+      "integrity": "sha512-CECvgRAWtUzuepdlPWd+VA7fhyF9HT183pZnl8wQw5x699Mk/MbME/q8xtULBfooi3LUbj6fToieNmsvUcDxWA==",
       "dev": true,
       "requires": {
         "vscode-json-languageservice": "^3.2.1"
@@ -2757,12 +2783,12 @@
       }
     },
     "flush-write-stream": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-      "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
       }
     },
     "fn.name": {
@@ -2836,7 +2862,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2854,11 +2881,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2871,15 +2900,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2982,7 +3014,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2992,6 +3025,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3004,17 +3038,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3031,6 +3068,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3103,7 +3141,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3113,6 +3152,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3188,7 +3228,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3218,6 +3259,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3235,6 +3277,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3273,11 +3316,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3873,23 +3918,23 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-nPvSZsVlbG9aLhZYaC3Oi1gT/tpyo3Yt5fNyf6NmcKIayz4VV/txxJFFKAK/gU4dcNn8ehsanBbVHVl0+amOLA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.2.tgz",
-      "integrity": "sha512-l7TD/VnBsIB2OJvSyxaLW/ab1+92dxZNH9wLH7uHPPioy3JZ8tnx2UXUdKmdkgmP2EFPzg64CToUP6dAS3U32Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/template": "7.0.0-beta.51",
-        "@babel/traverse": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "istanbul-lib-coverage": "^2.0.1",
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
         "semver": "^5.5.0"
       }
     },
@@ -3899,9 +3944,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3943,9 +3988,9 @@
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonc-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.2.tgz",
-      "integrity": "sha512-TSU435K5tEKh3g7bam1AFf+uZrISheoDsLlpmAo6wWZYqjsnd09lHYK1Qo+moK4Ikifev1Gdpa69g4NELKnCrQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.0.3.tgz",
+      "integrity": "sha512-WJi9y9ABL01C8CxTKxRRQkkSpY/x2bo4Gy0WuiZGrInxQqgxQpvkBCLNcDYcHOSdhx4ODgbFcgAvfL49C+PHgQ==",
       "dev": true
     },
     "jsonify": {
@@ -4056,11 +4101,6 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.memoize": {
       "version": "3.0.4",
@@ -4516,17 +4556,14 @@
       "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
     },
     "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "npm": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-6.7.0.tgz",
-      "integrity": "sha512-OtxCLzx+pcsjMGrjZpBp214ZjxzHcAe3zLYIlaVpRYqFHff6bgggyTLf2OZPO8lfxN0RHLJnFFUU016JCzM/Ww==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-6.8.0.tgz",
+      "integrity": "sha512-xMH6V0OCSJ5ZET6yWPI3BmJSqMMCuVJSIcLx3LSH/SrratFSt6EDuCuGRFMQYty98Q1l6x/7vKmfURosoyWgrA==",
       "requires": {
         "JSONStream": "^1.3.5",
         "abbrev": "~1.1.1",
@@ -4597,22 +4634,22 @@
         "move-concurrently": "^1.0.1",
         "node-gyp": "^3.8.0",
         "nopt": "~4.0.1",
-        "normalize-package-data": "~2.4.0",
+        "normalize-package-data": "^2.5.0",
         "npm-audit-report": "^1.3.2",
         "npm-cache-filename": "~1.0.2",
         "npm-install-checks": "~3.0.0",
         "npm-lifecycle": "^2.1.0",
         "npm-package-arg": "^6.1.0",
-        "npm-packlist": "^1.2.0",
+        "npm-packlist": "^1.3.0",
         "npm-pick-manifest": "^2.2.3",
         "npm-profile": "*",
-        "npm-registry-fetch": "^3.8.0",
+        "npm-registry-fetch": "^3.9.0",
         "npm-user-validate": "~1.0.0",
         "npmlog": "~4.1.2",
         "once": "~1.4.0",
         "opener": "^1.5.1",
         "osenv": "^0.1.5",
-        "pacote": "^9.4.0",
+        "pacote": "^9.4.1",
         "path-is-inside": "~1.0.2",
         "promise-inflight": "~1.0.1",
         "qrcode-terminal": "^0.12.0",
@@ -4622,7 +4659,7 @@
         "read-cmd-shim": "~1.0.1",
         "read-installed": "~4.0.3",
         "read-package-json": "^2.0.13",
-        "read-package-tree": "^5.2.1",
+        "read-package-tree": "^5.2.2",
         "readable-stream": "^3.1.1",
         "readdir-scoped-modules": "*",
         "request": "^2.88.0",
@@ -4836,10 +4873,6 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
           "bundled": true
         },
         "builtins": {
@@ -5747,13 +5780,6 @@
           "version": "2.1.0",
           "bundled": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
@@ -6355,13 +6381,22 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.10.0",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.6"
+              }
+            }
           }
         },
         "npm-audit-report": {
@@ -6373,7 +6408,7 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-cache-filename": {
@@ -6416,7 +6451,7 @@
           }
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -6442,7 +6477,7 @@
           }
         },
         "npm-registry-fetch": {
-          "version": "3.8.0",
+          "version": "3.9.0",
           "bundled": true,
           "requires": {
             "JSONStream": "^1.3.4",
@@ -6555,7 +6590,7 @@
           }
         },
         "pacote": {
-          "version": "9.4.0",
+          "version": "9.4.1",
           "bundled": true,
           "requires": {
             "bluebird": "^3.5.3",
@@ -6653,6 +6688,10 @@
         },
         "path-key": {
           "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
           "bundled": true
         },
         "performance-now": {
@@ -6825,7 +6864,7 @@
           }
         },
         "read-package-tree": {
-          "version": "5.2.1",
+          "version": "5.2.2",
           "bundled": true,
           "requires": {
             "debuglog": "^1.0.1",
@@ -7558,90 +7597,52 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-12.0.2.tgz",
-      "integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+      "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.2.0",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^2.1.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.5",
-        "istanbul-reports": "^1.4.1",
-        "md5-hex": "^1.2.0",
+        "caching-transform": "^3.0.1",
+        "convert-source-map": "^1.6.0",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.1.0",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.1",
+        "make-dir": "^1.3.0",
         "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
-        "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "test-exclude": "^5.1.0",
+        "uuid": "^3.3.2",
+        "yargs": "^12.0.5",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "bundled": true,
           "dev": true
         },
         "append-transform": {
-          "version": "0.4.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "^2.0.0"
           }
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
           "bundled": true,
           "dev": true
         },
@@ -7650,80 +7651,18 @@
           "bundled": true,
           "dev": true
         },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
         "async": {
-          "version": "1.5.2",
+          "version": "2.6.2",
           "bundled": true,
-          "dev": true
-        },
-        "atob": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -7734,118 +7673,30 @@
             "concat-map": "0.0.1"
           }
         },
-        "braces": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cache-base": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
-          }
-        },
         "caching-transform": {
-          "version": "1.0.1",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "hasha": "^3.0.0",
+            "make-dir": "^1.3.0",
+            "package-hash": "^3.0.0",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "camelcase": {
-          "version": "1.2.1",
+          "version": "5.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
+          "dev": true
         },
         "cliui": {
-          "version": "2.1.0",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -7853,22 +7704,14 @@
           "bundled": true,
           "dev": true
         },
-        "collection-visit": {
-          "version": "1.0.0",
+        "commander": {
+          "version": "2.17.1",
           "bundled": true,
           "dev": true,
-          "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
-          }
+          "optional": true
         },
         "commondir": {
           "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
           "bundled": true,
           "dev": true
         },
@@ -7878,14 +7721,12 @@
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.5.1",
+          "version": "1.6.0",
           "bundled": true,
-          "dev": true
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         },
         "cross-spawn": {
           "version": "4.0.2",
@@ -7897,93 +7738,54 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
           "bundled": true,
           "dev": true
         },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
         "default-require-extensions": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "^3.0.0"
           }
         },
-        "define-property": {
-          "version": "2.0.2",
+        "end-of-stream": {
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
+            "once": "^1.4.0"
           }
         },
         "error-ex": {
-          "version": "1.3.1",
+          "version": "1.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true
+        },
         "execa": {
-          "version": "0.7.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -7992,183 +7794,36 @@
           },
           "dependencies": {
             "cross-spawn": {
-              "version": "5.1.0",
+              "version": "6.0.5",
               "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.1",
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
               }
             }
           }
         },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
         "find-cache-dir": {
-          "version": "0.1.1",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "find-up": {
-          "version": "2.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "^3.0.0"
           }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
         },
         "foreground-child": {
           "version": "1.5.6",
@@ -8179,36 +7834,26 @@
             "signal-exit": "^3.0.0"
           }
         },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-cache": "^0.2.2"
-          }
-        },
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
         "get-caller-file": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true
         },
         "get-stream": {
-          "version": "3.0.0",
+          "version": "4.1.0",
           "bundled": true,
-          "dev": true
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8221,62 +7866,43 @@
           }
         },
         "graceful-fs": {
-          "version": "4.1.11",
+          "version": "4.1.15",
           "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.11",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
+            "async": "^2.5.0",
             "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.4.4",
+              "version": "0.6.1",
               "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
+              "dev": true
             }
           }
         },
-        "has-value": {
-          "version": "1.0.0",
+        "has-flag": {
+          "version": "3.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
-          }
+          "dev": true
         },
-        "has-values": {
-          "version": "1.0.0",
+        "hasha": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "is-stream": "^1.0.1"
           }
         },
         "hosted-git-info": {
-          "version": "2.6.0",
+          "version": "2.7.1",
           "bundled": true,
           "dev": true
         },
@@ -8300,63 +7926,12 @@
           "dev": true
         },
         "invert-kv": {
-          "version": "1.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
           "bundled": true,
           "dev": true
         },
@@ -8365,54 +7940,8 @@
           "bundled": true,
           "dev": true
         },
-        "is-number": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
@@ -8421,127 +7950,111 @@
           "bundled": true,
           "dev": true
         },
-        "isobject": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "istanbul-lib-coverage": {
-          "version": "1.2.0",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.1.0",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "^0.4.0"
+            "append-transform": "^1.0.0"
           }
         },
         "istanbul-lib-report": {
-          "version": "1.1.3",
+          "version": "2.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "supports-color": "^6.0.0"
           },
           "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
             "supports-color": {
-              "version": "3.2.3",
+              "version": "6.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.5",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
           },
           "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
+            "source-map": {
+              "version": "0.6.1",
               "bundled": true,
               "dev": true
             }
           }
         },
-        "longest": {
-          "version": "1.0.1",
+        "istanbul-reports": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "handlebars": "^4.1.0"
+          }
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
           "bundled": true,
           "dev": true
         },
         "lru-cache": {
-          "version": "4.1.3",
+          "version": "4.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8549,38 +8062,30 @@
             "yallist": "^2.1.2"
           }
         },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-visit": "^1.0.0"
-          }
-        },
-        "md5-hex": {
+        "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "pify": "^3.0.0"
           }
         },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
+        "map-age-cleaner": {
+          "version": "0.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "p-defer": "^1.0.0"
+          }
+        },
+        "mem": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
           }
         },
         "merge-source-map": {
@@ -8593,33 +8098,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -8639,28 +8117,9 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "0.0.10",
           "bundled": true,
           "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
         },
         "mkdirp": {
           "version": "0.5.1",
@@ -8668,46 +8127,32 @@
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "nanomatch": {
-          "version": "1.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
           },
           "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
+            "minimist": {
+              "version": "0.0.8",
               "bundled": true,
               "dev": true
             }
           }
         },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
+            "resolve": "^1.10.0",
             "semver": "2 || 3 || 4 || 5",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -8724,47 +8169,6 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.0"
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          }
         },
         "once": {
           "version": "1.4.0",
@@ -8789,61 +8193,75 @@
           "dev": true
         },
         "os-locale": {
-          "version": "2.1.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
+        "p-is-promise": {
           "version": "2.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
           "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-exists": {
+        "p-limit": {
           "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "p-try": "^2.0.0"
           }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "package-hash": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
+            "lodash.flattendeep": "^4.4.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -8856,115 +8274,71 @@
           "dev": true
         },
         "path-parse": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true,
           "dev": true
         },
         "path-type": {
-          "version": "1.1.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
-          "version": "2.3.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
         },
         "pkg-dir": {
-          "version": "1.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^3.0.0"
           }
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
           "bundled": true,
           "dev": true
         },
-        "read-pkg": {
-          "version": "1.1.0",
+        "pump": {
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
-        "regex-not": {
-          "version": "1.0.2",
+        "release-zalgo": {
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "es6-error": "^4.0.1"
           }
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -8976,48 +8350,34 @@
           "bundled": true,
           "dev": true
         },
-        "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ret": {
-          "version": "0.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
+        "resolve": {
+          "version": "1.10.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "align-text": "^0.1.1"
+            "path-parse": "^1.0.6"
           }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
-        "safe-regex": {
-          "version": "1.1.0",
+        "safe-buffer": {
+          "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ret": "~0.1.10"
-          }
+          "dev": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true
         },
@@ -9025,27 +8385,6 @@
           "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "set-value": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
         },
         "shebang-command": {
           "version": "1.2.0",
@@ -9065,133 +8404,6 @@
           "bundled": true,
           "dev": true
         },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "atob": "^2.1.1",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
         "spawn-wrap": {
           "version": "1.4.2",
           "bundled": true,
@@ -9206,7 +8418,7 @@
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
+          "version": "3.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9215,7 +8427,7 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
+          "version": "2.2.0",
           "bundled": true,
           "dev": true
         },
@@ -9229,36 +8441,9 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.0"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -9278,12 +8463,9 @@
           }
         },
         "strip-bom": {
-          "version": "2.0.0",
+          "version": "3.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
+          "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
@@ -9291,166 +8473,41 @@
           "dev": true
         },
         "test-exclude": {
-          "version": "4.2.1",
+          "version": "5.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
             "require-main-filename": "^1.0.1"
           }
         },
-        "to-object-path": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        },
         "uglify-js": {
-          "version": "2.8.29",
+          "version": "3.4.9",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
+            "source-map": {
+              "version": "0.6.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
+              "optional": true
             }
           }
         },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "union-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
-              }
-            }
-          }
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
-              },
-              "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-values": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
+        "uuid": {
+          "version": "3.3.2",
           "bundled": true,
           "dev": true
         },
-        "use": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "validate-npm-package-license": {
-          "version": "3.0.3",
+          "version": "3.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9470,12 +8527,6 @@
           "version": "2.0.0",
           "bundled": true,
           "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -9530,17 +8581,17 @@
           "dev": true
         },
         "write-file-atomic": {
-          "version": "1.3.4",
+          "version": "2.4.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "signal-exit": "^3.0.2"
           }
         },
         "y18n": {
-          "version": "3.2.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true
         },
@@ -9550,62 +8601,31 @@
           "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
+          "version": "12.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            },
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "8.1.0",
+          "version": "11.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
-            }
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -9651,9 +8671,9 @@
       "dev": true
     },
     "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
       "dev": true
     },
     "object-visit": {
@@ -9780,9 +8800,9 @@
       }
     },
     "parse-asn1": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.3.tgz",
-      "integrity": "sha512-VrPoetlz7B/FqjBLD2f5wBVZvsZVLnRUrxVLfRYhGXCODa/NWE4p3Wp+6+aV3ZPL3KM7/OZmxDIwwijD7yuucg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
+      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
       "requires": {
         "asn1.js": "^4.0.0",
         "browserify-aes": "^1.0.0",
@@ -9912,13 +8932,14 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "propget": {
@@ -10001,9 +9022,9 @@
       "dev": true
     },
     "randombytes": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
-      "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "requires": {
         "safe-buffer": "^5.1.0"
       }
@@ -10016,6 +9037,12 @@
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
+    },
+    "react-is": {
+      "version": "16.8.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
+      "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+      "dev": true
     },
     "read-only-stream": {
       "version": "2.0.0",
@@ -10908,9 +9935,9 @@
       }
     },
     "toml": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.5.tgz",
-      "integrity": "sha512-ulY/Z2yPWKl/3JvGJvnEe7mXqVt2+TtDoRxJNgTAwO+3lwXefeCHS697NN0KRy6q7U/b1MnSnj/UGF/4U0U2WQ=="
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ=="
     },
     "trim-right": {
       "version": "1.0.1",
@@ -11005,11 +10032,12 @@
       "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow=="
     },
     "undeclared-identifiers": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
-      "integrity": "sha512-13EaeocO4edF/3JKime9rD7oB6QI8llAGhgn5fKOPyfkJbRb6NFv9pYV6dFEmpa4uRjKeBqLZP8GpuzqHlKDMQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+      "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
       "requires": {
         "acorn-node": "^1.3.0",
+        "dash-ast": "^1.0.0",
         "get-assigned-identifiers": "^1.2.0",
         "simple-concat": "^1.0.0",
         "xtend": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A set of different workers for building frontend applications",
   "main": "index.js",
   "scripts": {
-    "eslint": "eslint-godaddy test/*.test.js ./*.js",
-    "test": "nyc npm run test:unit",
+    "lint": "eslint-godaddy test/*.test.js ./*.js",
+    "test": "npm run lint && nyc npm run test:unit",
     "test:unit": "mocha test/*.test.js",
     "test:debug": "npm run test:unit -- --inspect-brk"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint-godaddy test/*.test.js ./*.js",
-    "test": "npm run lint && nyc npm run test:unit",
+    "test": "nyc npm run test:unit",
+    "posttest": "npm run lint",
     "test:unit": "mocha test/*.test.js",
     "test:debug": "npm run test:unit -- --inspect-brk"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "eslint": "eslint-godaddy test/*.test.js ./*.js",
-    "test": "nyc mocha test/*.test.js"
+    "test": "nyc npm run test:unit",
+    "test:unit": "mocha test/*.test.js",
+    "test:debug": "npm run test:unit -- --inspect-brk"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/warehouseai/workers-factory#readme",
   "dependencies": {
+    "@wrhs/extract-config": "^1.0.0",
     "async": "~2.1.4",
     "babel-core": "~6.21.0",
     "babel-preset-es2015": "~6.18.0",
@@ -57,6 +58,6 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-react": "^7.1.0",
     "mocha": "^5.2.0",
-    "nyc": "^12.0.2"
+    "nyc": "^13.3.0"
   }
 }


### PR DESCRIPTION
Now that [`@wrhs/extract-config`](https://www.npmjs.com/package/@wrhs/extract-config) exists, we can update this to get all of the relevant config once.

I made sure to not change the tests to ensure that this still works in the exact same way.