### PR TITLE
[minor] do not set fingerprint of map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [#19] Do not set `fingerprint` property on `.map` files. `bffs` will do this now.
+
 ### 1.7.6
 
 - [#18] Add collected documentation and badges.
@@ -8,3 +10,4 @@
   - Update `tar-fs@1.16` to resolve security warning
 
 [#18]: https://github.com/warehouseai/extract-config/pull/18
+[#19]: https://github.com/warehouseai/extract-config/pull/19

--- a/minifiers/uglifyjs.js
+++ b/minifiers/uglifyjs.js
@@ -67,7 +67,7 @@ module.exports = function uglify(options, done) {
   if (results.error) return done(results.error);
 
   //
-  // Get hash for content. The sourceMap and JS content need to be stored under the same hash.
+  // Get hash for content.
   //
   const fingerprint = fingerprinter(options.file, { content: results.code, map: true });
 
@@ -77,8 +77,7 @@ module.exports = function uglify(options, done) {
     filename: filename
   }, {
     [map]: {
-      content: results.map,
-      fingerprint: fingerprint.id
+      content: results.map
     }
   });
 };

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -369,6 +369,7 @@ describe('Factory', function () {
         assume(factory.output['index.min.js'].content.toString()).to.include('\n//# sourceMappingURL=index.min.js.map');
         assume(factory.output['index.min.js'].fingerprint).to.equal('8fbdebb353a0952379baef3ec769bd9d');
         assume(factory.output['index.min.js.map'].content).to.be.instanceof(Buffer);
+        assume(factory.output['index.min.js.map']).to.not.have.property('sourcemap');
 
         assume(sourceMap).to.be.an('object');
         assume(sourceMap).to.have.property('version', 3);

--- a/test/factory.test.js
+++ b/test/factory.test.js
@@ -369,7 +369,7 @@ describe('Factory', function () {
         assume(factory.output['index.min.js'].content.toString()).to.include('\n//# sourceMappingURL=index.min.js.map');
         assume(factory.output['index.min.js'].fingerprint).to.equal('8fbdebb353a0952379baef3ec769bd9d');
         assume(factory.output['index.min.js.map'].content).to.be.instanceof(Buffer);
-        assume(factory.output['index.min.js.map']).to.not.have.property('sourcemap');
+        assume(factory.output['index.min.js.map']).to.not.have.property('fingerprint');
 
         assume(sourceMap).to.be.an('object');
         assume(sourceMap).to.have.property('version', 3);


### PR DESCRIPTION
## Summary

Remove the forceful setting of property `fingerprint` on the `.map` file. This will be done by `bffs` from now on with https://github.com/warehouseai/bffs/pull/15

- [x] requires https://github.com/warehouseai/bffs/pull/15 to be merged and published first.

## Changelog

DONE

## Test Plan

`npm test` runs as expected. Assertion against the removed property was added. It wasn't test against to begin with.
